### PR TITLE
org.apache.druid.data.input.AvroStreamInputFormatTest.testParseSchema…

### DIFF
--- a/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
+++ b/extensions-core/avro-extensions/src/test/java/org/apache/druid/data/input/AvroStreamInputRowParserTest.java
@@ -342,6 +342,8 @@ public class AvroStreamInputRowParserTest
 
   static void assertInputRowCorrect(InputRow inputRow, List<String> expectedDimensions, boolean isFromPigAvro)
   {
+    Collections.sort(expectedDimensions);
+    Collections.sort(inputRow.getDimensions());
     Assert.assertEquals(expectedDimensions, inputRow.getDimensions());
     Assert.assertEquals(1543698L, inputRow.getTimestampFromEpoch());
 


### PR DESCRIPTION
# What is the purpose of this PR
This PR fixes the flaky tests of org.apache.druid.data.input.AvroStreamInputFormatTest.testParseSchemaless.

# Why the tests fail
org.apache.druid.data.input.AvroStreamInputFormatTest.testParseSchemaless occurs because of a comparison issue involving a **predefined ArrayList of strings** and an **ArrayList of strings (retrieved via the List<String> getDimensions()** method) from an instance of a class, specifically **[MapBasedInputRow](https://github.com/mahbubsumon085/druid-fixflaky/blob/fix-flaky-testparseschemaless/processing/src/main/java/org/apache/druid/data/input/MapBasedInputRow.java)**, which implements the **[InputRow](https://github.com/mahbubsumon085/druid-fixflaky/blob/master/processing/src/main/java/org/apache/druid/data/input/InputRow.java)** interface. The InputRow interface defines the method List<String> **getDimensions**(). The data for this list is supplied by an instance of the **[InputRowSchema](https://github.com/mahbubsumon085/druid-fixflaky/blob/master/processing/src/main/java/org/apache/druid/data/input/InputRowSchema.java)** class, an extension of the abstract class **[IntermediateRowParsingReader](https://github.com/mahbubsumon085/druid-fixflaky/blob/master/processing/src/main/java/org/apache/druid/data/input/IntermediateRowParsingReader.java)**. Within this class, the ArrayList of strings is created using a map, and the inherent nature of the map introduces uncertainty regarding the predefined order.


# Reproduce the test failure.
Run the test with the NonDex maven plugin. The commands to recreate the flaky test failures are:
sudo  mvn -pl extensions-core/avro-extensions edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.druid.data.input.AvroStreamInputFormatTest#testParseSchemaless

# Expected results
The tests should pass when run with NonDex.

# Actual Result
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR] org.apache.druid.data.input.AvroStreamInputFormatTest.testParseSchemaless
[ERROR]   Run 1: AvroStreamInputFormatTest.testParseSchemaless:434 expected:<[nestedArrayVal, someOtherId, someIntArray, someFloat, someUnion, eventType, id, someFixed, someBytes, someEnum, someLong, someInt, timestamp]> but was:<[nestedArrayVal, someFloat, id, someInt, someEnum, someFixed, someBytes, someIntArray, timestamp, someUnion, eventType, someOtherId, someLong]>
[ERROR]   Run 2: AvroStreamInputFormatTest.testParseSchemaless:434 expected:<[nestedArrayVal, someOtherId, someIntArray, someFloat, someUnion, eventType, id, someFixed, someBytes, someEnum, someLong, someInt, timestamp]> but was:<[nestedArrayVal, id, timestamp, someFixed, someLong, someEnum, someOtherId, someIntArray, someFloat, someBytes, someInt, eventType, someUnion]>
[ERROR]   Run 3: AvroStreamInputFormatTest.testParseSchemaless:434 expected:<[nestedArrayVal, someOtherId, someIntArray, someFloat, someUnion, eventType, id, someFixed, someBytes, someEnum, someLong, someInt, timestamp]> but was:<[nestedArrayVal, someBytes, someUnion, someFloat, someFixed, timestamp, someEnum, someOtherId, eventType, someIntArray, someInt, id, someLong]>
[ERROR]   Run 4: AvroStreamInputFormatTest.testParseSchemaless:434 expected:<[nestedArrayVal, someOtherId, someIntArray, someFloat, someUnion, eventType, id, someFixed, someBytes, someEnum, someLong, someInt, timestamp]> but was:<[nestedArrayVal, someOtherId, someUnion, timestamp, someBytes, someEnum, eventType, someFixed, someIntArray, id, someInt, someFloat, someLong]>
[INFO] 
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
INFO: Surefire failed when running tests for IZ78mx435R5jAH7zgqS9i5uBdHG8zEpApslqxnq08=
[INFO] NonDex SUMMARY:


# Fix
Fixed the issue using **Collections.Sort()** method for both ArrayList of  String.